### PR TITLE
Add `php-parallel-lint` for syntax validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,12 @@
 		"rocklobsterinc/functions": "^v1.0.4",
 		"rocklobsterinc/form-data-tree": "^v2.0.3"
 	},
+	"require-dev": {
+		"php-parallel-lint/php-parallel-lint": "^1.4"
+	},
+	"scripts": {
+		"lint": "parallel-lint src/"
+	},
 	"autoload": {
 		"psr-4": {
 			"RockLobsterInc\\Swv\\": "src/"


### PR DESCRIPTION
Adds `php-parallel-lint` as a dev dependency to catch PHP syntax errors early. 

### Changes

- Added `php-parallel-lint/php-parallel-lint` to `require-dev`
- Added Composer script `lint` to run syntax check on files in `src/`
- Added `.gitignore` to ignore `vendor/` and `composer.lock`

### Usage

Run
```
composer lint
```

### Related

This would have caught #10 early by reporting
```
Syntax error found in 1 file

------------------------------------------------------------
Parse error: src/InvalidityException.php:37
    35|          * Retrieves the validation error message.
    36|          */
  > 37|         public function getMessage() {
    38|                 if ( $this->cause instanceof self ) {
    39|                         return $this->cause->message;
Cannot override final method Exception::getMessage()
Script parallel-lint src/ handling the lint event returned with error code 1
```
